### PR TITLE
BL Touch sensor and command pins were swapped

### DIFF
--- a/Firmware/Klipper/generic-bigtreetech-octopus-max-ez.cfg
+++ b/Firmware/Klipper/generic-bigtreetech-octopus-max-ez.cfg
@@ -304,8 +304,8 @@ aliases:
 # See the sample-lcd.cfg file for definitions of common LCD displays.
 
 #[bltouch]
-#sensor_pin: PB14
-#control_pin: PB15
+#sensor_pin: PB15
+#control_pin: PB14
 
 # Proximity switch
 #[probe]


### PR DESCRIPTION
As I was setting up klipper with my new board, I had trouble getting the BL Touch sensor to work.  It turned out the issue was the sensor pin and control pins are backwards in the example config.